### PR TITLE
Fix: Improve Material 3 theme and component styling

### DIFF
--- a/app/src/main/res/drawable/bottom_nav_item_color_selector.xml
+++ b/app/src/main/res/drawable/bottom_nav_item_color_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/neon_teal" android:state_checked="true"/>
+    <item android:color="@color/on_surface_variant" android:state_checked="false"/>
+</selector>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -11,4 +11,5 @@
          If specific on_error for night is needed, it should be defined here. -->
     <!-- Primary, Secondary, Tertiary neon colors from the main colors.xml are assumed to be used
          unless specific night versions are required. -->
+    <color name="neon_teal_transparent">#3300FFCC</color> <!-- 20% opacity for neon_teal -->
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,6 +4,7 @@
     <color name="neon_teal">#00FFCC</color>
     <color name="neon_purple">#FF00FF</color>
     <color name="neon_blue">#00FFFF</color>
+    <color name="neon_teal_transparent">#3300FFCC</color> <!-- 20% opacity for neon_teal -->
 
     <!-- Background Colors -->
     <color name="dark_background">#1A1A2E</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -67,6 +67,11 @@
         <item name="materialButtonStyle">@style/Widget.AuraFrameFX.Button</item>
         <item name="materialCardViewStyle">@style/Widget.AuraFrameFX.CardView</item>
         <!-- Add other default widget styles here -->
+        <item name="chipStyle">@style/Widget.AuraFrameFX.Chip</item>
+        <item name="floatingActionButtonStyle">@style/Widget.AuraFrameFX.FloatingActionButton</item>
+        <item name="textInputStyle">@style/Widget.AuraFrameFX.TextInputLayout.FilledBox</item>
+        <item name="materialToolbarStyle">@style/Widget.AuraFrameFX.Toolbar</item>
+        <item name="bottomNavigationStyle">@style/Widget.AuraFrameFX.BottomNavigationView</item>
 
     </style>
 
@@ -105,6 +110,53 @@
     <style name="ShapeAppearance.AuraFrameFX.LargeComponent" parent="ShapeAppearance.Material3.LargeComponent">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">16dp</item> <!-- Example adjustment -->
+    </style>
+
+    <!-- Chip Style -->
+    <style name="Widget.AuraFrameFX.Chip" parent="Widget.Material3.Chip.Assist">
+        <item name="chipBackgroundColor">@color/surface_variant</item>
+        <item name="android:textColor">@color/on_surface</item>
+        <item name="chipStrokeColor">@color/neon_teal</item>
+        <item name="chipStrokeWidth">1dp</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.AuraFrameFX.SmallComponent</item>
+    </style>
+
+    <!-- FloatingActionButton Style -->
+    <style name="Widget.AuraFrameFX.FloatingActionButton" parent="Widget.Material3.FloatingActionButton.Primary">
+        <item name="backgroundTint">@color/neon_purple</item>
+        <item name="tint">@color/on_primary</item> <!-- For the icon -->
+        <item name="shapeAppearance">@style/ShapeAppearance.AuraFrameFX.LargeComponent</item>
+    </style>
+
+    <!-- TextInputLayout Style (FilledBox) -->
+    <style name="Widget.AuraFrameFX.TextInputLayout.FilledBox" parent="Widget.Material3.TextInputLayout.FilledBox">
+        <item name="boxBackgroundColor">@color/surface_variant</item>
+        <item name="android:textColorHint">@color/on_surface_variant</item>
+        <item name="hintTextColor">@color/neon_teal</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.AuraFrameFX.SmallComponent</item>
+        <item name="endIconTint">@color/neon_teal</item>
+        <item name="startIconTint">@color/neon_teal</item>
+    </style>
+
+    <!-- Toolbar Style -->
+    <style name="Widget.AuraFrameFX.Toolbar" parent="Widget.Material3.Toolbar">
+        <item name="android:background">@color/surface</item>
+        <item name="titleTextColor">@color/on_surface</item>
+        <item name="subtitleTextColor">@color/on_surface_variant</item>
+        <item name="navigationIconTint">@color/neon_teal</item> <!-- For hamburger/back icon -->
+        <item name="menuIconTint">@color/neon_teal</item> <!-- For overflow menu icon, if applicable -->
+    </style>
+
+    <!-- BottomNavigationView Style -->
+    <style name="Widget.AuraFrameFX.BottomNavigationView" parent="Widget.Material3.BottomNavigationView.ActiveIndicator">
+        <item name="android:background">@color/surface</item>
+        <item name="itemIconTint">@drawable/bottom_nav_item_color_selector</item>
+        <item name="itemTextColor">@drawable/bottom_nav_item_color_selector</item>
+        <item name="itemActiveIndicatorStyle">@style/Widget.AuraFrameFX.BottomNavigationView.ActiveIndicator</item>
+    </style>
+
+    <style name="Widget.AuraFrameFX.BottomNavigationView.ActiveIndicator" parent="Widget.Material3.BottomNavigationView.ActiveIndicator">
+        <item name="android:color">@color/neon_teal_transparent</item> <!-- Example, define neon_teal_transparent in colors.xml -->
     </style>
 
 </resources>

--- a/app/src/main/res/values/typography.xml
+++ b/app/src/main/res/values/typography.xml
@@ -32,20 +32,20 @@
         <item name="android:textColor">@color/on_surface</item>
     </style>
     <style name="TextAppearance.AuraFrameFX.TitleMedium" parent="TextAppearance.Material3.TitleMedium">
-        <item name="android:textColor">@color/on_surface_variant</item>
+        <item name="android:textColor">@color/on_surface</item>
     </style>
     <style name="TextAppearance.AuraFrameFX.TitleSmall" parent="TextAppearance.Material3.TitleSmall">
-        <item name="android:textColor">@color/on_surface_variant</item>
+        <item name="android:textColor">@color/on_surface</item>
     </style>
 
     <style name="TextAppearance.AuraFrameFX.BodyLarge" parent="TextAppearance.Material3.BodyLarge">
         <item name="android:textColor">@color/on_surface</item>
     </style>
     <style name="TextAppearance.AuraFrameFX.BodyMedium" parent="TextAppearance.Material3.BodyMedium">
-        <item name="android:textColor">@color/on_surface_variant</item>
+        <item name="android:textColor">@color/on_surface</item>
     </style>
     <style name="TextAppearance.AuraFrameFX.BodySmall" parent="TextAppearance.Material3.BodySmall">
-        <item name="android:textColor">@color/on_surface_variant</item>
+        <item name="android:textColor">@color/on_surface</item>
         <item name="android:textSize">12sp</item> <!-- Example customization -->
     </style>
 
@@ -53,9 +53,9 @@
         <item name="android:textColor">@color/neon_teal</item> <!-- Example: Accent color for labels -->
     </style>
     <style name="TextAppearance.AuraFrameFX.LabelMedium" parent="TextAppearance.Material3.LabelMedium">
-        <item name="android:textColor">@color/on_surface_variant</item>
+        <item name="android:textColor">@color/on_surface</item>
     </style>
     <style name="TextAppearance.AuraFrameFX.LabelSmall" parent="TextAppearance.Material3.LabelSmall">
-        <item name="android:textColor">@color/on_surface_variant</item>
+        <item name="android:textColor">@color/on_surface</item>
     </style>
 </resources>


### PR DESCRIPTION
This commit addresses issues with text appearances and Material 3 component styling within the AuraFrameFX theme.

Key changes include:

1.  **Improved Text Contrast:**
    - Modified `app/src/main/res/values/typography.xml` to use `@color/on_surface` (white) for several text appearances (`TitleMedium`, `TitleSmall`, `BodyMedium`, `BodySmall`, `LabelMedium`, `LabelSmall`) when they are likely to appear on `surface_variant` backgrounds. This enhances readability by increasing contrast.

2.  **Default Styles for Material 3 Components:**
    - Added default styles in `app/src/main/res/values/themes.xml` for common Material 3 components: - `Chip` (`Widget.AuraFrameFX.Chip`) - `FloatingActionButton` (`Widget.AuraFrameFX.FloatingActionButton`) - `TextInputLayout` (`Widget.AuraFrameFX.TextInputLayout.FilledBox`) - `Toolbar` (`Widget.AuraFrameFX.Toolbar`) - `BottomNavigationView` (`Widget.AuraFrameFX.BottomNavigationView`)
    - These styles ensure that the components align with the custom neon theme's colors and shapes.
    - Added a new color `neon_teal_transparent` in `app/src/main/res/values/colors.xml` and `app/src/main/res/values-night/colors.xml`.
    - Created a new drawable `app/src/main/res/drawable/bottom_nav_item_color_selector.xml` for `BottomNavigationView` item tinting.

3.  **Theme Review:**
    - Verified that shape appearances are correctly defined and applied.
    - Reviewed the night mode theme (`values-night/`) to ensure consistency and proper dark theme adaptations. The night theme leverages the updated typography and component styles effectively.

These changes aim to provide a more consistent and visually polished user interface, addressing the reported styling issues.