### PR TITLE
Fix: Resolve AAPT errors for Material 3 themes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,9 @@ dependencies {
     // Google AI Generative AI
     implementation(libs.google.ai.generativeai)
 
+    // Google Material Components
+    implementation(libs.google.android.material)
+
     // Networking (OkHttp & Retrofit)
     implementation(libs.okhttp.core)
     implementation(libs.okhttp.logging.interceptor) // Useful for debugging

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ androidxTestExtJunit = "1.1.5"
 androidxEspressoCore = "3.5.1"
 mockk = "1.13.10"
 googleAiGenerativeai = "0.3.0"
+googleMaterial = "1.12.0"
 # Plugin specific versions from root build.gradle.kts
 googleServicesPlugin = "4.4.1"
 firebaseCrashlyticsPlugin = "2.9.9"
@@ -87,6 +88,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
 google-ai-generativeai = { group = "com.google.ai.client.generativeai", name = "generativeai", version.ref = "googleAiGenerativeai" }
+google-android-material = { group = "com.google.android.material", name = "material", version.ref = "googleMaterial" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" } # AGP is fine with version


### PR DESCRIPTION
Added the `com.google.android.material:material` dependency. This library provides the necessary Material 3 attributes and base styles required for XML themes, resolving AAPT errors where resources like `attr/cornerFamily` or styles like
`ShapeAppearance.Material3.LargeComponent` were not found.

The app's `themes.xml` references Material 3 theme attributes and parent styles. The Jetpack Compose Material 3 library (`androidx.compose.material3`) is primarily for Composable functions and does not alone provide these XML theme resources. The inclusion of the Material Components for Android library bridges this gap.