### PR TITLE
Fix: Resolve XML resource errors and duplicates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ android {
 dependencies {
     // AndroidX Core
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.appcompat) // If using AppCompat themes/views
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -112,23 +112,6 @@
         <item name="cornerSize">16dp</item> <!-- Example adjustment -->
     </style>
 
-    <!-- Text Appearances -->
-    <style name="TextAppearance.AuraFrameFX.DisplayLarge" parent="TextAppearance.Material3.DisplayLarge"></style>
-    <style name="TextAppearance.AuraFrameFX.DisplayMedium" parent="TextAppearance.Material3.DisplayMedium"></style>
-    <style name="TextAppearance.AuraFrameFX.DisplaySmall" parent="TextAppearance.Material3.DisplaySmall"></style>
-    <style name="TextAppearance.AuraFrameFX.HeadlineLarge" parent="TextAppearance.Material3.HeadlineLarge"></style>
-    <style name="TextAppearance.AuraFrameFX.HeadlineMedium" parent="TextAppearance.Material3.HeadlineMedium"></style>
-    <style name="TextAppearance.AuraFrameFX.HeadlineSmall" parent="TextAppearance.Material3.HeadlineSmall"></style>
-    <style name="TextAppearance.AuraFrameFX.TitleLarge" parent="TextAppearance.Material3.TitleLarge"></style>
-    <style name="TextAppearance.AuraFrameFX.TitleMedium" parent="TextAppearance.Material3.TitleMedium"></style>
-    <style name="TextAppearance.AuraFrameFX.TitleSmall" parent="TextAppearance.Material3.TitleSmall"></style>
-    <style name="TextAppearance.AuraFrameFX.BodyLarge" parent="TextAppearance.Material3.BodyLarge"></style>
-    <style name="TextAppearance.AuraFrameFX.BodyMedium" parent="TextAppearance.Material3.BodyMedium"></style>
-    <style name="TextAppearance.AuraFrameFX.BodySmall" parent="TextAppearance.Material3.BodySmall"></style>
-    <style name="TextAppearance.AuraFrameFX.LabelLarge" parent="TextAppearance.Material3.LabelLarge"></style>
-    <style name="TextAppearance.AuraFrameFX.LabelMedium" parent="TextAppearance.Material3.LabelMedium"></style>
-    <style name="TextAppearance.AuraFrameFX.LabelSmall" parent="TextAppearance.Material3.LabelSmall"></style>
-
     <!-- Chip Style -->
     <style name="Widget.AuraFrameFX.Chip" parent="Widget.Material3.Chip.Assist">
         <item name="chipBackgroundColor">@color/surface_variant</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ hilt = "2.50" # Hilt version
 
 # AndroidX
 androidxCore = "1.13.1"
+androidxCoreSplashscreen = "1.0.1"
 androidxAppCompat = "1.6.1"
 androidxActivity = "1.8.2" # For Activity Compose
 androidxLifecycle = "2.7.0"
@@ -50,6 +51,7 @@ dokkaPlugin = "1.9.20"
 [libraries]
 # AndroidX Core
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "androidxCoreSplashscreen" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }


### PR DESCRIPTION
This commit addresses several issues causing "Cannot resolve symbol" and "Duplicate definitions" errors in XML resource files:

1.  Consolidated TextAppearances: Removed duplicate `TextAppearance.AuraFrameFX.*` style definitions from `themes.xml`. The definitions in `typography.xml` are now the single source of truth, and `themes.xml` correctly references them.

2.  Added Core SplashScreen Dependency: Added `androidx.core:core-splashscreen:1.0.1` to provide the necessary resources for `splash_screen.xml` (e.g., `Theme.SplashScreen` and related attributes).

3.  Verified Material Components Dependency: Confirmed that `com.google.android.material:material` (version 1.12.0) is correctly included, which provides the base Material 3 XML resources needed by `themes.xml` and `typography.xml`.

These changes should allow the IDE and build system to correctly resolve the referenced Material 3 and SplashScreen resources.