### PR TITLE
Fix: Add missing repository declarations for dependencies

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,12 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS) // Recommended
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+        maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
+    }
     versionCatalogs {
         create("libs")
     }


### PR DESCRIPTION
The project was failing to resolve dependencies with errors like "Cannot resolve external dependency ... because no repositories are defined."

This was caused by a missing `repositories` block within the `dependencyResolutionManagement` section of `settings.gradle.kts`.

This commit adds the required `repositories` block, including:
- google()
- mavenCentral()
- maven { url = uri("https.jitpack.io") }
- maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }

This should allow Gradle to find and download project dependencies.